### PR TITLE
fix: improve upsert success summary

### DIFF
--- a/app/api/ingest/upsert/route.ts
+++ b/app/api/ingest/upsert/route.ts
@@ -104,6 +104,16 @@ export async function POST(req: NextRequest) {
     const allModelIds: Array<string | number> = []
     const upsertedModelIds: Array<string | number> = []
     const potentialTwins: Array<{ modelId: string | number | null; potential_twins: any }> = []
+    const successes: Array<{
+      rowIndex: number
+      modelName: string
+      modelId: string | number
+      outcome: 'inserted' | 'merged' | 'updated'
+      dedupeStatus: string | null
+      originalModelId: string | number | null
+      mergedIntoModelId: string | number | null
+      mergedFromModelIds: Array<string | number>
+    }> = []
     let processed = 0
     let succeeded = 0
     let failed = 0
@@ -180,13 +190,38 @@ export async function POST(req: NextRequest) {
         //   review_results, merges, original_model_id, potential_twins
         // }
         const result = json as any
-        const isSuccess = result?.success === true
         const returnedId = result?.model_id
+        const merges = Array.isArray(result?.merges) ? result.merges : []
+        const successfulMerges = merges.filter((merge: any) => merge?.success !== false)
+        const mergedFromModelIds = successfulMerges
+          .map((merge: any) => merge?.source_model_id ?? merge?.merged_model_id ?? merge?.from_model_id)
+          .filter((id: any) => id != null)
+        const dedupeStatus = typeof result?.dedupe_status === 'string' ? result.dedupe_status : null
+        const hasErrors = !!(result?.errors && typeof result.errors === 'object' && Object.keys(result.errors).length > 0)
+        const hasReturnedId = returnedId != null && returnedId !== ''
+        const isEffectiveSuccess = hasReturnedId && !hasErrors
 
-        if (isSuccess && returnedId) {
+        if (isEffectiveSuccess) {
           succeeded++
           allModelIds.push(returnedId)
           upsertedModelIds.push(returnedId)
+
+          const outcome: 'inserted' | 'merged' | 'updated' = mergedFromModelIds.length > 0
+            ? 'merged'
+            : dedupeStatus === 'matched_existing' || dedupeStatus === 'updated_existing'
+            ? 'updated'
+            : 'inserted'
+
+          successes.push({
+            rowIndex,
+            modelName,
+            modelId: returnedId,
+            outcome,
+            dedupeStatus,
+            originalModelId: result?.original_model_id ?? null,
+            mergedIntoModelId: outcome === 'merged' ? returnedId : null,
+            mergedFromModelIds,
+          })
 
           const twinInfo = result?.potential_twins
           if (
@@ -212,10 +247,10 @@ export async function POST(req: NextRequest) {
 
           if (errors && typeof errors === 'object' && Object.keys(errors).length > 0) {
             errorMessage = JSON.stringify(errors, null, 2)
-          } else if (!isSuccess) {
+          } else if (!hasReturnedId) {
+            errorMessage = 'Upsert failed: backend did not return a model_id'
+          } else {
             errorMessage = 'Upsert failed (no errors dict provided)'
-          } else if (!returnedId) {
-            errorMessage = 'Upsert succeeded but no model_id returned'
           }
 
           failures.push({
@@ -241,6 +276,7 @@ export async function POST(req: NextRequest) {
         insertedModelIds: upsertedModelIds, 
         allModelIds, 
         modelIds: upsertedModelIds, 
+        successes: { count: succeeded, items: successes },
         potentialTwins, 
         warnings: { count: skipped, items: warnings },
         failures: { count: failed, items: failures }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,19 @@ interface UploadResponse {
   data?: any
 }
 
+function formatOutcomeLabel(outcome: string | null | undefined) {
+  switch (outcome) {
+    case 'merged':
+      return 'Merged'
+    case 'updated':
+      return 'Updated'
+    case 'inserted':
+      return 'Inserted'
+    default:
+      return 'Succeeded'
+  }
+}
+
 export default function Home() {
   const [file, setFile] = useState<File | null>(null)
   const [isUploading, setIsUploading] = useState(false)
@@ -803,7 +816,7 @@ export default function Home() {
                 // Hide modelIds on success
                 const dataToShow = uploadResult.success
                   ? (() => {
-                      const { modelIds, ...rest } = uploadResult.data || {}
+                      const { modelIds, successes, ...rest } = uploadResult.data || {}
                       return Object.keys(rest || {}).length ? rest : null
                     })()
                   : uploadResult.data
@@ -813,6 +826,40 @@ export default function Home() {
                     <pre className="whitespace-pre-wrap">
                       {JSON.stringify(dataToShow, null, 2)}
                     </pre>
+                  </div>
+                )
+              })()}
+              {(() => {
+                const successes = Array.isArray(uploadResult.data?.successes?.items) ? uploadResult.data.successes.items : []
+                if (!successes.length) return null
+                return (
+                  <div className="mt-4 text-xs">
+                    <div className="font-semibold text-green-800">Successful Models ({successes.length})</div>
+                    <div className="mt-2 space-y-2">
+                      {successes.map((s: any, idx: number) => {
+                        const mergedFrom = Array.isArray(s?.mergedFromModelIds) ? s.mergedFromModelIds : []
+                        return (
+                          <div key={`success-${idx}`} className="p-2 rounded border border-green-200 bg-green-50">
+                            <div className="font-medium text-green-900">
+                              Row {s?.rowIndex ?? 'unknown'} • {s?.modelName ?? 'Unknown model'}
+                            </div>
+                            <div className="text-green-800 mt-1">
+                              {formatOutcomeLabel(s?.outcome)} as model_id {String(s?.modelId ?? 'unknown')}
+                            </div>
+                            {s?.dedupeStatus && (
+                              <div className="text-green-700 mt-1">
+                                Dedupe status: {String(s.dedupeStatus)}
+                              </div>
+                            )}
+                            {mergedFrom.length > 0 && (
+                              <div className="text-green-700 mt-1">
+                                Merged models: {mergedFrom.join(', ')}
+                              </div>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
                   </div>
                 )
               })()}


### PR DESCRIPTION
## Summary\n- treat upserts with a returned model_id and no backend errors as successful\n- add a structured success summary for inserted, updated, and merged models\n- show a clearer per-row success log in the import console UI\n- keep failure cards for real backend errors or missing model_id responses\n\n## Notes\n- pulled latest main before branching\n- local build was not runnable in this workspace because node_modules are not installed ()\n